### PR TITLE
New Feature: set 'credentials=include' to support additional CI systems

### DIFF
--- a/src/components/DataInput.vue
+++ b/src/components/DataInput.vue
@@ -25,6 +25,7 @@
       :onNewReport="onNewReport"
       v-if="reportSource === ReportSource.Url"
       :presetUrl="this.presetUrl"
+      :includeCredentials="this.includeCredentials"
     />
 
     <v-autocomplete
@@ -65,6 +66,7 @@ export default class DataInput extends Vue {
   private reportSource = ReportSource.File
   private ReportSource = ReportSource
   @Prop() private presetUrl?: string
+  @Prop() private includeCredentials?: string
   @Ref() readonly fileAgent!: {
     deleteFileRecord: (fileRecordOrRaw: FileRecord) => void
   }

--- a/src/components/ReportUrlFetcher.vue
+++ b/src/components/ReportUrlFetcher.vue
@@ -52,6 +52,28 @@
                 with the scope read_api.
               </v-col>
             </v-row>
+            <v-row>
+              <v-col>
+                <v-checkbox
+                  v-model="setIncludeCredentials"
+                  label="Send session credentials to remote host"
+                ></v-checkbox>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                If this flag is set, 'credentials=include' is set when
+                requesting the Trivy json. This allows downloading artifacts
+                from CI servers like Jenkins. This option can also be enabled
+                via the 'includeCredentials=true' url parameter. Don't forget to
+                configure CORS properly on the CI system, especially the related
+                <a
+                  href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials"
+                  >Access-Control-Allow-Credentials</a
+                >
+                header.
+              </v-col>
+            </v-row>
           </v-container>
         </v-card-text>
         <v-card-actions>
@@ -84,6 +106,7 @@ const ReportUrlFetcherProps = Vue.extend({
   props: {
     onNewReport: Function,
     presetUrl: String,
+    includeCredentials: String,
   },
 })
 Vue.use(VueFileAgent)
@@ -92,12 +115,16 @@ Vue.use(VueFileAgent)
 })
 export default class ReportUrlFetcher extends ReportUrlFetcherProps {
   private url = ""
+  private setIncludeCredentials = false
   private state = "ready"
   private dialog = false
   private headerName = ""
   private headerValue = ""
   mounted(): void {
     this.loadAuthorization()
+    if (this.includeCredentials) {
+      this.setIncludeCredentials = this.includeCredentials == "true"
+    }
     if (this.presetUrl) {
       this.url = this.presetUrl
       this.fetchReportFromUrl()
@@ -106,10 +133,16 @@ export default class ReportUrlFetcher extends ReportUrlFetcherProps {
   public loadAuthorization(): void {
     this.headerName = localStorage.getItem("headerName") || ""
     this.headerValue = localStorage.getItem("headerValue") || ""
+    this.setIncludeCredentials =
+      localStorage.getItem("includeCredentials") == "true"
   }
   public saveAuthorization(): void {
     localStorage.setItem("headerName", this.headerName)
     localStorage.setItem("headerValue", this.headerValue)
+    localStorage.setItem(
+      "includeCredentials",
+      this.setIncludeCredentials ? "true" : "false"
+    )
     this.dialog = false
   }
 
@@ -121,7 +154,12 @@ export default class ReportUrlFetcher extends ReportUrlFetcherProps {
         headers[this.headerName] = this.headerValue
       }
       try {
-        const response = await fetch(this.url, { headers })
+        const fetchArgs: Record<string, string | object> = { headers }
+        if (this.setIncludeCredentials) {
+          fetchArgs["credentials"] = "include"
+          console.log("setting credentials")
+        }
+        const response = await fetch(this.url, fetchArgs)
         this.state = "ready"
         const contentType = response.headers.get("content-type")
         if (

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,10 @@ const routes: Array<RouteConfig> = [
     path: "/",
     name: "Home",
     component: Home,
-    props: (route) => ({ presetUrl: route.query.url }),
+    props: (route) => ({
+      presetUrl: route.query.url,
+      includeCredentials: route.query.includeCredentials,
+    }),
   },
   {
     path: "/about",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -23,6 +23,7 @@
       <DataInput
         @inputChanged="reactivelySetNewVulnerabilities"
         :presetUrl="this.presetUrl"
+        :includeCredentials="this.includeCredentials"
       />
       <DataTable :selectedVulnerabilities="selectedVulnerabilities"></DataTable>
     </v-container>
@@ -44,6 +45,7 @@ import { Component, Prop } from "vue-property-decorator"
 })
 export default class Home extends Vue {
   @Prop() private presetUrl?: string
+  @Prop() private includeCredentials?: string
   private selectedVulnerabilities: Vulnerability[] = []
 
   private reactivelySetNewVulnerabilities(newVulnerabilities: Vulnerability[]) {


### PR DESCRIPTION
Hi,

we found your great project while we were searching for a good visualization for the trivy artefacts.

As we are using Jenkins for our CI Pipelines we need a different authentication mechanism. After some investigation we decided the most efficient way would be to use the existing authentication the user already has. This can be archived by setting the adequate CORS headers on the CI server - but it also requires an option on the fetch request.

With this PR we want to contribute the changes we made back to this project. The option on the fetch request could be enabled by setting a checkbox in the "Authorization" config page. Additionally the option could be enabled by adding a 'includeCredentials=true' query parameter to the url.

Bye,
     Chris